### PR TITLE
fix: :arrow-up: update @nuxt/icon dependency.

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -2,7 +2,7 @@ export const INIT_DEPS = ["radix-vue", "tailwind-variants"];
 export const INIT_DEV_DEPS = [
   "typescript",
   "tailwindcss-animate",
-  "nuxt-icon",
+  "@nuxt/icon",
   "prettier-plugin-tailwindcss",
   "prettier",
   "@nuxtjs/tailwindcss",
@@ -16,7 +16,7 @@ export const INIT_MODULES = [
   "@nuxtjs/tailwindcss",
   "@nuxtjs/color-mode",
   "@vueuse/nuxt",
-  "nuxt-icon",
+  "@nuxt/icon",
 ];
 
 export const CSS_THEME_OPTIONS = [


### PR DESCRIPTION
nuxt-icon was renamed to @nuxt-icon here [https://github.com/nuxt/icon/pull/175](https://github.com/nuxt/icon/pull/175)
